### PR TITLE
Prepares release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,7 @@
-#### [0.4.2-unstable (latest)](https://github.com/niaid/moleculer-netsparker-cloud/)
-
-
-##### FEATURE
-- 
+#### [0.5.0 (2024-05-08)](https://github.com/niaid/moleculer-netsparker-cloud/releases/tag/0.5.0)
 
 ##### IMPROVEMENT
 - Upgrade `netsparker-cloud-js` to 0.4.0; includes potentially breaking changes from upstream API
-
-##### BUG FIX
-- 
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "moleculer-netsparker-cloud",
-  "version": "0.4.2-unstable",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "moleculer-netsparker-cloud",
-      "version": "0.4.2-unstable",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "netsparker-cloud": "github:niaid/netsparker-cloud-js#0.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moleculer-netsparker-cloud",
-  "version": "0.4.2-unstable",
+  "version": "0.5.0",
   "description": "Moleculer mixin for consuming Netsparker Cloud services.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
- minor bump for potentially breaking changes due to `netsparker-cloud-js` upgrade to 0.4.0